### PR TITLE
fix: update EXDNOTES_INTERNAL_API port

### DIFF
--- a/tutornotes/patches/openedx-lms-common-settings
+++ b/tutornotes/patches/openedx-lms-common-settings
@@ -1,3 +1,3 @@
 # Student notes
 EDXNOTES_CLIENT_NAME = "notes"
-EDXNOTES_INTERNAL_API = "http://notes:8000/api/v1"
+EDXNOTES_INTERNAL_API = "http://notes:8120/api/v1"


### PR DESCRIPTION
According to the docker file this service is listening on port 8120, but LMS cannot find service when attempting to access the Notes page within a course. Meanwhile, notes can be successfully created and fetched on unit pages since it is using the public API. Changing the port from 8000 to 8120 for the internal API allows for the Notes page to work correctly.